### PR TITLE
removed quotes and spaces

### DIFF
--- a/weblate/environment
+++ b/weblate/environment
@@ -1,8 +1,8 @@
 # Weblate setup
 WEBLATE_DEBUG=1
-WEBLATE_ADMIN_NAME='Weblate Admin'
-WEBLATE_ADMIN_EMAIL='noreply@weblate.org'
-WEBLATE_EMAIL='noreply@weblate.org'
+WEBLATE_ADMIN_NAME=Weblate Admin
+WEBLATE_ADMIN_EMAIL=noreply@weblate.org
+WEBLATE_EMAIL=noreply@weblate.org
 
 # MySQL setup
 MYSQL_ROOT_PASSWORD=weblate
@@ -15,6 +15,6 @@ POSTGRES_PASSWORD=weblate
 POSTGRES_USER=weblate
 
 # Mail server, the server has to listen on port 587 and understand TLS
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_HOST_USER = ''
-EMAIL_HOST_PASSWORD = ''
+EMAIL_HOST=smtp.gmail.com
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=

--- a/weblate/environment
+++ b/weblate/environment
@@ -16,5 +16,7 @@ POSTGRES_USER=weblate
 
 # Mail server, the server has to listen on port 587 and understand TLS
 EMAIL_HOST=smtp.gmail.com
+# Do NOT use quotes here
 EMAIL_HOST_USER=
+# Do NOT use quotes here
 EMAIL_HOST_PASSWORD=


### PR DESCRIPTION
Quotes in environment variables result in issues, because they are directly passed to the python variables.